### PR TITLE
UI-oppdateringer: Søkefelt og kartlag-knapper i Google Maps-stil

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,10 +28,88 @@
             height: 100%;
         }
 
+        /* ── Map search overlay (Google Maps style) ── */
+        #map-search-overlay {
+            position: absolute;
+            top: 14px;
+            left: 14px;
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            gap: 10px;
+            max-width: calc(100vw - 28px);
+            z-index: 1100;
+        }
+
+        #map-search-overlay .search-box {
+            margin-bottom: 0;
+            width: 380px;
+            flex-shrink: 0;
+        }
+
+        /* ── Google Maps-style layer chip row ── */
+        #layer-chips {
+            display: flex;
+            flex-wrap: nowrap;
+            gap: 8px;
+            align-items: center;
+        }
+
+        .layer-chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 10px 18px;
+            background: #ffffff;
+            border-radius: 24px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18), 0 1px 3px rgba(0, 0, 0, 0.12);
+            font-size: 15px;
+            font-weight: 600;
+            color: #3c4043;
+            cursor: pointer;
+            user-select: none;
+            transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+            white-space: nowrap;
+        }
+
+        .layer-chip:hover {
+            background: #f1f3f4;
+            box-shadow: 0 3px 10px rgba(0, 0, 0, 0.22);
+        }
+
+        /* Hide the raw checkbox but keep it functional */
+        .layer-chip input[type="checkbox"] {
+            position: absolute;
+            opacity: 0;
+            width: 0;
+            height: 0;
+            pointer-events: none;
+        }
+
+        /* Active (checked) chip style */
+        .layer-chip:has(input:checked) {
+            background: #f1f3f4;
+            color: #3c4043;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18), 0 1px 3px rgba(0, 0, 0, 0.12);
+        }
+
+        .layer-chip:has(input:checked) .chip-dot {
+            opacity: 1;
+        }
+
+        .chip-dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            flex-shrink: 0;
+            opacity: 0.45;
+            transition: opacity 0.15s ease;
+        }
+
         #ui-container {
             position: absolute;
-            top: 10px;
-            left: 10px;
+            top: 82px;
+            left: 12px;
             width: 320px;
             z-index: 1000;
             display: flex;
@@ -58,19 +136,47 @@
             font-size: 14px;
         }
 
+        /* ── Google Maps-style search bar ── */
         .search-box {
             display: flex;
-            gap: 5px;
-            margin-bottom: 10px;
+            align-items: center;
+            background: #ffffff;
+            border-radius: 28px;
+            box-shadow: 0 2px 12px rgba(0, 0, 0, 0.22), 0 1px 4px rgba(0, 0, 0, 0.14);
+            padding: 0 8px 0 20px;
+            margin-bottom: 0;
+            min-height: 52px;
+            transition: box-shadow 0.2s ease;
+        }
+
+        .search-box:focus-within {
+            box-shadow: 0 4px 18px rgba(0, 0, 0, 0.22), 0 2px 6px rgba(0, 0, 0, 0.14);
+        }
+
+        .search-box .search-icon {
+            color: #9aa0a6;
+            font-size: 18px;
+            margin-right: 12px;
+            flex-shrink: 0;
+            pointer-events: none;
         }
 
         input[type="text"] {
             flex: 1;
-            padding: 8px;
-            border: 1px solid #ccc;
-            border-radius: 4px;
+            padding: 14px 0;
+            border: none;
+            outline: none;
+            background: transparent;
+            font-size: 16px;
+            color: #202124;
+            font-family: inherit;
         }
 
+        input[type="text"]::placeholder {
+            color: #9aa0a6;
+        }
+
+        /* Generic button reset (keeps other buttons intact) */
         button {
             padding: 8px 12px;
             border: none;
@@ -83,6 +189,28 @@
 
         button:hover {
             background: #1d4ed8;
+        }
+
+        /* Search submit button — icon-only pill inside the bar */
+        #btn-search {
+            width: 44px;
+            height: 44px;
+            padding: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            border-radius: 50%;
+            background: #1a73e8;
+            color: #fff;
+            font-size: 17px;
+            flex-shrink: 0;
+            margin-left: 6px;
+            transition: background 0.15s ease, transform 0.1s ease;
+        }
+
+        #btn-search:hover {
+            background: #1765cc;
+            transform: scale(1.05);
         }
 
         select {
@@ -227,6 +355,43 @@
 <body>
     <div id="map"></div>
 
+    <!-- Google Maps-style floating search bar + chip row -->
+    <div id="map-search-overlay">
+        <div class="search-box">
+            <i class="fa-solid fa-magnifying-glass search-icon"></i>
+            <input type="text" id="search-input" placeholder="Search address...">
+            <button id="btn-search"><i class="fa-solid fa-magnifying-glass"></i></button>
+        </div>
+
+        <!-- Layer filter chips — labels wrap the real checkboxes so existing JS fires on change -->
+        <div id="layer-chips">
+            <label class="layer-chip">
+                <input type="checkbox" id="toggle-drikkevann" checked>
+                <span class="chip-dot" style="background:#3b82f6;"></span>
+                <i class="fa-solid fa-droplet" style="font-size:12px;"></i>
+                Drinking Water
+            </label>
+            <label class="layer-chip">
+                <input type="checkbox" id="toggle-brannstasjoner" checked>
+                <span class="chip-dot" style="background:#ef4444;"></span>
+                <i class="fa-solid fa-fire-extinguisher" style="font-size:12px;"></i>
+                Fire Stations
+            </label>
+            <label class="layer-chip">
+                <input type="checkbox" id="toggle-sykehus" checked>
+                <span class="chip-dot" style="background:#10b981;"></span>
+                <i class="fa-solid fa-hospital" style="font-size:12px;"></i>
+                Hospitals
+            </label>
+            <label class="layer-chip">
+                <input type="checkbox" id="toggle-tilfluktsrom" checked>
+                <span class="chip-dot" style="background:#f59e0b;"></span>
+                <i class="fa-solid fa-shield-halved" style="font-size:12px;"></i>
+                Shelters
+            </label>
+        </div>
+    </div>
+
     <div id="custom-map-controls">
         <button id="btn-locate" class="map-btn-custom" title="Finn min posisjon">
             <i class="fa-solid fa-crosshairs"></i>
@@ -244,20 +409,8 @@
 
     <div id="ui-container">
         <div class="panel-box">
-            <h3><i class="fa-solid fa-route"></i> Find Shelter</h3>
-
-            <div class="search-box">
-                <input type="text" id="search-input" placeholder="Search address...">
-                <button id="btn-search"><i class="fa-solid fa-magnifying-glass"></i></button>
-            </div>
-
-            <div style="text-align: center; margin: 5px 0; font-size: 0.8em; color: #666;">- or -</div>
-
-            <button id="btn-find-me" style="width: 100%; background: #0f172a;">
-                <i class="fa-solid fa-location-arrow"></i> Use my location
-            </button>
-
-            <hr style="border: 0; border-top: 1px solid #eee; margin: 15px 0;">
+            <!-- Top controls hidden at user request; btn-find-me kept in DOM for JS binding -->
+            <button id="btn-find-me" style="display:none;"></button>
 
             <label for="target-category" style="font-size: 0.9em; font-weight: bold;">What are you looking for?</label>
             <select id="target-category">
@@ -293,12 +446,9 @@
             </div>
         </div>
 
-        <div class="panel-box" id="layer-control">
+        <!-- Layer control panel hidden — checkboxes now live in the chip overlay above -->
+        <div class="panel-box" id="layer-control" style="display:none;" aria-hidden="true">
             <h3>View (Layers)</h3>
-            <label><input type="checkbox" id="toggle-drikkevann" checked /> Drinking Water</label>
-            <label><input type="checkbox" id="toggle-brannstasjoner" checked /> Fire Stations</label>
-            <label><input type="checkbox" id="toggle-sykehus" checked /> Hospitals</label>
-            <label><input type="checkbox" id="toggle-tilfluktsrom" checked /> Shelters</label>
         </div>
     </div>
 


### PR DESCRIPTION
Endringer: - Flyttet søkefelt ut av sidepanelet og la det som et flytende overlegg på kartet. - Oppdatert CSS for at søkefeltet skal se ut som Google Maps (avrundet, hvit bakgrunn, innfelt søkeikon). - Erstattet de vertikale sjekkboksene for kartlag med horisontale toggle-chips under søkefeltet. - Fjernet 'Find Shelter', linjedeler og 'Use my location' fra grensesnittet for et renere design, samtidig som vi skjuler (og beholder i DOM-en) den underliggende logikken slik at ingen hendelseslyttere i app.js brekker.